### PR TITLE
Imp backends in config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### unreleased
 - Apply corporative styles
 - Add legal text
+- IMP: move backends to config
 
 ### 0.9.0 (2025-07-01)
 - NEW users backend

--- a/config/conf.yaml.example
+++ b/config/conf.yaml.example
@@ -85,3 +85,8 @@ sendgrid_api_key: 'key'
 email:
   default_from: 'example@email.com'
   bcc: 'example@email.com'
+
+authentication_backends:
+  - 'som_cas.backends.SocisBackend'
+  - 'som_cas.backends.SomETBackend'
+  - 'som_cas.backends.UsuarisBackend'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -99,7 +99,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 AUTH_USER_MODEL = 'som_cas.SomUser'
 
-AUTHENTICATION_BACKENDS = config.get('authentication_backends', ['som_cas.backends.SocisBackend'])
+AUTHENTICATION_BACKENDS = config.get('authentication_backends', ['som_cas.backends.UsuarisBackend'])
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -99,11 +99,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 AUTH_USER_MODEL = 'som_cas.SomUser'
 
-AUTHENTICATION_BACKENDS = [
-    'som_cas.backends.UsuarisBackend',
-    'som_cas.backends.SocisBackend',
-    'som_cas.backends.SomETBackend',
-]
+AUTHENTICATION_BACKENDS = config.get('authentication_backends', ['som_cas.backends.SocisBackend'])
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/


### PR DESCRIPTION
## Description

List of backends for authorization is fixed

## Changes

- Move list of backends to config file for flexibility
- SocisBackend is set as default
- Current available backends are: 
 'som_cas.backends.SocisBackend': only memebers are authorized
 'som_cas.backends.SomETBackend': only ET users are authorized
 'som_cas.backends.UsuarisBackend': all users are authorized (returns a field saying user is member or not)
- As this respond to Django AUTHENTICATION_BACKENDS then backends should be executed in order of the list, that means if the user is not authenticated for the first backend then the next backend in the list is tested.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Deploy notes

Add configuration authentication_backends with list of backends to config/conf.yaml.  An exmple of configuration of this variable can be found in config/conf.yaml.example
